### PR TITLE
fix: 修复 sse Event 对象 __str__ 未返回值的问题

### DIFF
--- a/zhipuai/utils/sse_client.py
+++ b/zhipuai/utils/sse_client.py
@@ -123,4 +123,4 @@ class Event(object):
             s += ", no data"
         if self.retry:
             s += ", retry in {0}ms".format(self.retry)
-        return
+        return s


### PR DESCRIPTION
修复出现的以下日志异常

```
TypeError: __str__ returned non-string (type NoneType)
Call stack:
  File "xxxxx\Python310\lib\threading.py", line 966, in _bootstrap
    self._bootstrap_inner()
  File "xxxxx\Python310\lib\threading.py", line 1009, in _bootstrap_inner
    self.run()
  File "xxxxx\utils\llm_api\llm_api.py", line 107, in run
    for chunk in response:
  File "xxxxx\utils\llm_api\llm_api.py", line 565, in create_chat_completion
    for event in response.events():
  File "xxxxx\venv\lib\site-packages\zhipuai\utils\sse_client.py", line 98, in events
    self._logger.debug("Dispatching %s...", event)
Message: 'Dispatching %s...'
```